### PR TITLE
chore: Use the latest version of the dune configuration API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
     - COMPILER="4.08.0"
     - NATIVE_COMP="yes"
     - COQ_VER="8.11.0"
-    - DUNE_VER="2.1.3"
+    - DUNE_VER="2.4.0"
 
 install:
   - curl -sL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh > install.sh

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build html
 
 build:
-	dune build
+	dune build @install
 
 install: build
 	dune install

--- a/dune-project
+++ b/dune-project
@@ -1,3 +1,3 @@
-(lang dune 1.9)
+(lang dune 2.4)
 (using coq 0.1)
 (name prelude)

--- a/theories/dune
+++ b/theories/dune
@@ -1,6 +1,6 @@
 (coq.theory
   (name Prelude)
-  (public_name prelude.Prelude)
+  (package prelude)
   (modules Init
            Data.Equality
            Data.Byte


### PR DESCRIPTION
Dune configuration file syntax is versioned, and with this commit we
explicitly use the 2.4 version of dune. We do that because the Coq
support of dune remains experimental, and therefore is subject to
change. For instance, the `public_name` stanza has been deprecated,
and there is no reason to continue using it. Besides, dune will soon
add support for compositional build of Coq libraries and we really
want to use that.